### PR TITLE
Adds AiClient facade

### DIFF
--- a/src/AiClient.php
+++ b/src/AiClient.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient;
+
+use WordPress\AiClient\Providers\Contracts\ProviderAvailabilityInterface;
+use WordPress\AiClient\Providers\ProviderRegistry;
+
+/**
+ * Main entry point for the AI Client SDK.
+ *
+ * This class provides static methods for accessing AI functionality,
+ * managing providers, and checking availability.
+ *
+ * @since n.e.x.t
+ */
+class AiClient
+{
+    /**
+     * @var ProviderRegistry|null The singleton provider registry instance.
+     */
+    protected static ?ProviderRegistry $registry = null;
+
+    /**
+     * Gets the default provider registry.
+     *
+     * The registry manages all registered AI providers and models,
+     * allowing for provider discovery and model selection based on capabilities.
+     *
+     * @since n.e.x.t
+     *
+     * @return ProviderRegistry The provider registry instance.
+     */
+    public static function defaultRegistry(): ProviderRegistry
+    {
+        if (self::$registry === null) {
+            self::$registry = new ProviderRegistry();
+        }
+
+        return self::$registry;
+    }
+
+    /**
+     * Checks if a provider is configured and available.
+     *
+     * This method delegates to the provider's availability checker
+     * to determine if it has been properly configured and is ready for use.
+     *
+     * @since n.e.x.t
+     *
+     * @param ProviderAvailabilityInterface $availability The availability checker.
+     * @return bool True if the provider is configured, false otherwise.
+     */
+    public static function isConfigured(ProviderAvailabilityInterface $availability): bool
+    {
+        return $availability->isConfigured();
+    }
+
+    /**
+     * Sets a custom provider registry.
+     *
+     * This method allows replacing the default registry with a custom one,
+     * useful for testing or custom provider configurations.
+     *
+     * @since n.e.x.t
+     *
+     * @param ProviderRegistry $registry The registry to use.
+     * @return void
+     */
+    public static function setRegistry(ProviderRegistry $registry): void
+    {
+        self::$registry = $registry;
+    }
+
+    /**
+     * Resets the registry to null.
+     *
+     * This forces a new registry to be created on the next access,
+     * useful for testing or clearing provider registrations.
+     *
+     * @since n.e.x.t
+     *
+     * @return void
+     */
+    public static function resetRegistry(): void
+    {
+        self::$registry = null;
+    }
+}

--- a/tests/unit/AiClientTest.php
+++ b/tests/unit/AiClientTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Providers\Contracts\ProviderAvailabilityInterface;
+use WordPress\AiClient\Providers\ProviderRegistry;
+
+/**
+ * Tests for the AiClient class.
+ *
+ * @covers \WordPress\AiClient\AiClient
+ */
+class AiClientTest extends TestCase
+{
+    /**
+     * Sets up the test environment.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Reset the registry before each test
+        AiClient::resetRegistry();
+    }
+
+    /**
+     * Tests that defaultRegistry returns a ProviderRegistry instance.
+     *
+     * @return void
+     */
+    public function testDefaultRegistryReturnsProviderRegistry(): void
+    {
+        $registry = AiClient::defaultRegistry();
+
+        $this->assertInstanceOf(ProviderRegistry::class, $registry);
+    }
+
+    /**
+     * Tests that defaultRegistry returns the same instance on multiple calls.
+     *
+     * @return void
+     */
+    public function testDefaultRegistryReturnsSameInstance(): void
+    {
+        $registry1 = AiClient::defaultRegistry();
+        $registry2 = AiClient::defaultRegistry();
+
+        $this->assertSame($registry1, $registry2);
+    }
+
+    /**
+     * Tests that setRegistry allows setting a custom registry.
+     *
+     * @return void
+     */
+    public function testSetRegistryAllowsCustomRegistry(): void
+    {
+        $customRegistry = new ProviderRegistry();
+        AiClient::setRegistry($customRegistry);
+
+        $registry = AiClient::defaultRegistry();
+
+        $this->assertSame($customRegistry, $registry);
+    }
+
+    /**
+     * Tests that resetRegistry clears the registry.
+     *
+     * @return void
+     */
+    public function testResetRegistryClearsRegistry(): void
+    {
+        $registry1 = AiClient::defaultRegistry();
+        AiClient::resetRegistry();
+        $registry2 = AiClient::defaultRegistry();
+
+        $this->assertNotSame($registry1, $registry2);
+    }
+
+    /**
+     * Tests that isConfigured delegates to the availability interface.
+     *
+     * @return void
+     */
+    public function testIsConfiguredDelegatesToAvailability(): void
+    {
+        $availability = $this->createMock(ProviderAvailabilityInterface::class);
+        $availability->expects($this->once())
+            ->method('isConfigured')
+            ->willReturn(true);
+
+        $result = AiClient::isConfigured($availability);
+
+        $this->assertTrue($result);
+    }
+
+    /**
+     * Tests that isConfigured returns false when not configured.
+     *
+     * @return void
+     */
+    public function testIsConfiguredReturnsFalseWhenNotConfigured(): void
+    {
+        $availability = $this->createMock(ProviderAvailabilityInterface::class);
+        $availability->expects($this->once())
+            ->method('isConfigured')
+            ->willReturn(false);
+
+        $result = AiClient::isConfigured($availability);
+
+        $this->assertFalse($result);
+    }
+}


### PR DESCRIPTION
This adds the `AiClient` class to add a means of referencing the registry. It doesn't add methods for things like the `PromptBuilder` and such, yet, as that will come in a subsequent PR introducing the builders.